### PR TITLE
Supclient: fetch: workaround for ie11.

### DIFF
--- a/SupClient/src/fetch.ts
+++ b/SupClient/src/fetch.ts
@@ -9,7 +9,18 @@ export default function fetch(url: string, type: string, callback: (err: Error, 
       return;
     }
 
-    callback(null, xhr.response);
+    // Workaround for IE11
+    let response = xhr.response;
+    if (type === "json" && typeof xhr.response === "string") {
+      console.log("SupClient: fetch: response was expected to be json, got a string instead. Now attempting to parse it as json...");
+      try {
+        response = JSON.parse(xhr.response);
+      } catch (e) {
+        console.log(e);
+        console.log("SupClient: fetch: failed to parse response as json.");
+      }
+    }
+    callback(null, response);
   };
 
   xhr.onerror = (event) => {


### PR DESCRIPTION
Add a workaround for IE11 in SupClient/src/fetch.ts.

IE11 doesn't automatically parse the XHR response as JSON even though "responseType" is set to "JSON" (it gives a string back instead). Try to detect and correct this issue at runtime.

I don't know what superpowers's policy on older browsers is, but given the simplicity of this workaround, I think it's worth merging it.
