### PR TITLE
Add writable data path next to the possibly read-only data path

### DIFF
--- a/SupClient/index.ts
+++ b/SupClient/index.ts
@@ -33,7 +33,7 @@ if ((global as any).SupApp == null) {
 }
 
 // Initialize empty system
-SupCore.system = new SupCore.System("", "");
+SupCore.system = new SupCore.System("", "", "");
 
 const plugins: { [contextName: string]: { [pluginName: string]: { path: string; content: any; } } } = {};
 

--- a/SupCore/SupCore.d.ts
+++ b/SupCore/SupCore.d.ts
@@ -322,13 +322,14 @@ declare namespace SupCore {
   }
 
   class System {
+    systemPath: string;
     id: string;
     folderName: string;
     data: SystemData;
     pluginsInfo: PluginsInfo;
     serverBuild: (server: ProjectServer, buildPath: string, callback: (err: string) => void) => void;
 
-    constructor(id: string, folderName: string);
+    constructor(systemPath: string, id: string, folderName: string);
     requireForAllPlugins(filePath: string): void;
     registerPlugin<T>(contextName: string, pluginName: string, plugin: T): void;
     getPlugins<T>(contextName: string): { [pluginName: string]: T };
@@ -337,6 +338,7 @@ declare namespace SupCore {
   // All loaded systems (server-side only)
   export const systems: { [system: string]: System };
   export const systemsPath: string;
+  export const rwSystemsPath: string;
   // The currently active system
   export let system: System;
 

--- a/SupCore/index.ts
+++ b/SupCore/index.ts
@@ -3,9 +3,11 @@ import * as Data from "./Data";
 export { Data };
 
 export let systemsPath: string;
+export let rwSystemsPath: string;
 
-export function setSystemsPath(path: string) {
+export function setSystemsPath(path: string, rwPath: string) {
   systemsPath = path;
+  rwSystemsPath = rwPath;
 }
 
 export * from "./systems";

--- a/SupCore/systems.ts
+++ b/SupCore/systems.ts
@@ -12,12 +12,12 @@ export class System {
   pluginsInfo: SupCore.PluginsInfo;
   serverBuild: (server: ProjectServer, buildPath: string, callback: (err: string) => void) => void;
 
-  constructor(public id: string, public folderName: string) {
+  constructor(public systemPath: string, public id: string, public folderName: string) {
     this.data = new SystemData(this);
   }
 
   requireForAllPlugins(filePath: string) {
-    const pluginsPath = path.resolve(`${SupCore.systemsPath}/${this.folderName}/plugins`);
+    const pluginsPath = path.resolve(`${this.systemPath}/${this.folderName}/plugins`);
 
     for (const pluginAuthor of fs.readdirSync(pluginsPath)) {
       const pluginAuthorPath = `${pluginsPath}/${pluginAuthor}`;

--- a/server/ProjectHub.ts
+++ b/server/ProjectHub.ts
@@ -19,10 +19,10 @@ export default class ProjectHub {
   serversById: { [serverId: string]: ProjectServer } = {};
   loadingProjectFolderName: string;
 
-  constructor(globalIO: SocketIO.Server, dataPath: string, callback: (err: Error) => any) {
+  constructor(globalIO: SocketIO.Server, dataPath: string, rwDataPath: string, callback: (err: Error) => any) {
     this.globalIO = globalIO;
-    this.projectsPath = path.join(dataPath, "projects");
-    this.buildsPath = path.join(dataPath, "builds");
+    this.projectsPath = path.join(rwDataPath, "projects");
+    this.buildsPath = path.join(rwDataPath, "builds");
 
     const serveProjects = (callback: ErrorCallback<NodeJS.ErrnoException>) => {
       async.eachSeries(fs.readdirSync(this.projectsPath), (folderName: string, cb: (err: Error) => any) => {

--- a/server/RemoteHubClient.ts
+++ b/server/RemoteHubClient.ts
@@ -35,7 +35,10 @@ export default class RemoteHubClient extends BaseRemoteClient {
     let formatVersion = SupCore.Data.ProjectManifest.currentFormatVersion;
     let templatePath: string;
     if (details.template != null) {
-      templatePath = `${SupCore.systemsPath}/${details.systemId}/public/templates/${details.template}`;
+      templatePath = `${SupCore.rwSystemsPath}/${details.systemId}/public/templates/${details.template}`;
+      if (!fs.existsSync(templatePath)) {
+        templatePath = `${SupCore.systemsPath}/${details.systemId}/public/templates/${details.template}`;
+      }
       formatVersion = JSON.parse(fs.readFileSync(path.join(templatePath, `manifest.json`), { encoding: "utf8" })).formatVersion;
     }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,13 +1,14 @@
 /// <reference path="index.d.ts" />
 
 import * as yargs from "yargs";
-import { dataPath } from "./commands/utils";
+import { dataPath, rwDataPath } from "./commands/utils";
 
 // Command line interface
 const argv = yargs
   .usage("Usage: $0 <command> [options]")
   .demand(1, "Enter a command")
-  .describe("data-path", "Path to store/read data files from, including config and projects")
+  .describe("data-path", "Path to read data files from")
+  .describe("rw-data-path", "Path to store/read data files from, including config and projects")
   .command("start", "Start the server", (yargs) => {
     yargs.demand(1, 1, `The "start" command doesn't accept any arguments`).argv;
   })
@@ -33,7 +34,7 @@ const command = argv._[0];
 const [ systemId, pluginFullName ] = argv._[1] != null ? argv._[1].split(":") : [ null, null ];
 switch (command) {
   /* tslint:disable */
-  case "start": require("./commands/start").default(dataPath); break;
+  case "start": require("./commands/start").default(dataPath, rwDataPath); break;
   case "registry": require("./commands/registry").default(); break;
   case "install": require("./commands/install").default(systemId, pluginFullName); break;
   case "uninstall": require("./commands/uninstall").default(systemId, pluginFullName); break;


### PR DESCRIPTION
The data path may point to the read only directory like
/app/Superpowers/core inside the flatpak sandbox. So we added the path
to the writable data directory which can be set with the
--rw-data-path option when running the server. This is where sessions,
superpowers, systems, config, plugins JSON files can be written.

I'm not sure if the patch is complete, but before continuing it, would this effort be welcome? By the way, the flatpak for superpowers I was working on is here - https://github.com/endlessm/superpowers-flatpak. You can read about flatpak here - http://flatpak.org. We use it at endless to provide applications.

I also have PRs for the game and app, will xref them there, when filing.